### PR TITLE
Helper extensions, change in make-process

### DIFF
--- a/examples/promise-examples.el
+++ b/examples/promise-examples.el
@@ -294,8 +294,8 @@ and resolves it in the output result."
     (then (lambda (result)
             (message "grep result:\n%s" result)))
 
-    (promise-catch (lambda (reason)
-                     (message "promise-catch: %s" reason)))))
+    (catch (lambda (reason)
+           (message "promise-catch: %s" reason)))))
 
 (defun example15 ()
   "An example when `make-process' returns an error."

--- a/promise.el
+++ b/promise.el
@@ -249,6 +249,16 @@ with stdout on success and with event on error."
   "Run script in shell and return"
   (promise:make-process-string shell-file-name shell-command-switch script))
 
+(defun promise:make-thread (f &rest args)
+  "Create thread and return promise with result of thread."
+  (promise-new
+   (lambda (resolve reject)
+     (make-thread
+      (lambda ()
+        (condition-case ex
+            (funcall resolve (apply f args))
+          (error (funcall reject ex))))))))
+
 (defun promise:url-retrieve (url)
   "Return `Promise' to resolve with response body of HTTP request."
   (promise-new

--- a/promise.el
+++ b/promise.el
@@ -245,6 +245,10 @@ with stdout on success and with event on error."
        (promise:maybe-message (propertize stderr 'face '(:foreground "red")))
        (promise-reject event)))))
 
+(defun promise:make-shell-command (script)
+  "Run script in shell and return"
+  (promise:make-process-string shell-file-name shell-command-switch script))
+
 (defun promise:url-retrieve (url)
   "Return `Promise' to resolve with response body of HTTP request."
   (promise-new

--- a/promise.el
+++ b/promise.el
@@ -104,13 +104,16 @@
        (lambda (value)
          ...))
 
-      (promise-catch
+      (catch
        (lambda (reason)
          ...))
 
       (done
        (lambda (value)
-         ...)))
+         ...))
+
+      (finally
+       (lambda () ...))
 
 as below.
 
@@ -125,7 +128,12 @@ as below.
 
       (setf promise (promise-done promise
                                   (lambda (reason)
-                                    ...))))"
+                                    ...)))
+
+      (setf promise (promise-finally promise
+                                     (lambda ()
+                                       ...)))
+      promise)"
   (declare (indent 1) (debug t))
   `(let ((promise ,(car body)))
      ,@(mapcar (lambda (sexp)
@@ -139,6 +147,8 @@ as below.
                        promise-done
                        promise-finally)
                       `(setf promise (,fn promise ,@args)))
+                     (catch
+                      `(setf promise (promise-catch promise ,@args)))
                      (then
                       `(setf promise (promise-then promise ,@args)))
                      (done
@@ -147,7 +157,8 @@ as below.
                       `(setf promise (promise-finally promise ,@args)))
                      (otherwise
                       sexp))))
-               (cdr body))))
+               (cdr body))
+     promise))
 
 ;;
 ;; Promise version of various utility functions

--- a/promise.el
+++ b/promise.el
@@ -259,6 +259,23 @@ with stdout on success and with event on error."
             (funcall resolve (apply f args))
           (error (funcall reject ex))))))))
 
+(defun promise:wrap-message (p)
+  "Wrap a promise with a result logger."
+  (promise-new
+   (lambda (resolve reject)
+     (promise-then
+      p
+      (lambda (res)
+        (message "%s: %s"
+                 (propertize "Result" 'face '(:foreground "green"))
+                 (string-trim-right res))
+        (funcall resolve res))
+      (lambda (err)
+        (message "%s: %s"
+                 (propertize "Error" 'face '(:foreground "red"))
+                 (string-trim-right err))
+        (funcall reject err))))))
+
 (defun promise:url-retrieve (url)
   "Return `Promise' to resolve with response body of HTTP request."
   (promise-new

--- a/promise.el
+++ b/promise.el
@@ -201,7 +201,10 @@ with (stdout stderr) on success and with (event stdout stderr) on error."
             (stderr-pipe (make-pipe-process
                           :name (concat "*" program "-stderr-pipe*")
                           :noquery t
-                          :buffer stderr))
+                          ;; use :filter instead of :buffer, to get rid of "Process Finished" lines
+                          :filter (lambda (_ output)
+                                    (with-current-buffer stderr
+                                      (insert output)))))
             (cleanup (lambda ()
                        (delete-process stderr-pipe)
                        (kill-buffer stdout)


### PR DESCRIPTION
Extracted some code from my melpa updater.

This should be a couple of pull requests. If you want to discuss separately, I'll split them up.

## promise-chain extension

Now also allows `(catch (lambda (error) ...))` clauses and returns the last promise.

## make-process change to return output strings

make-process is changed, to capture stdout and stderr separately and to delete temporary buffers. This allows for much nicer usage. Since promise resolves when process finishes, passing the process object won't allow any deeper interactions, anyways.

## add make-shell-command

A promise to run code in a shell

## add make-thread

A promise to run a function in a separate thread

## add wrap-message

A logging promise