### PR TITLE
Add make-process-with-string and with-buffer-string promise

### DIFF
--- a/promise-core.el
+++ b/promise-core.el
@@ -184,8 +184,7 @@
                (promise--resolve .promise ret)))))))))
 
 (defun promise--resolve (self new-value)
-  "Promise Resolution Procedure.
-See: https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure"
+  "Promise Resolution Procedure: https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure"
   (cl-block nil
     (when (eq new-value self)
       (cl-return (promise--reject

--- a/promise-core.el
+++ b/promise-core.el
@@ -184,7 +184,8 @@
                (promise--resolve .promise ret)))))))))
 
 (defun promise--resolve (self new-value)
-  "Promise Resolution Procedure: https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure"
+  "Promise Resolution Procedure.
+See: https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure"
   (cl-block nil
     (when (eq new-value self)
       (cl-return (promise--reject

--- a/promise.el
+++ b/promise.el
@@ -211,7 +211,7 @@ with stdin `buffer-string' of BUF."
 (defun promise:make-process-with-string (program string &rest args)
   "Generate an asynchronous process and return Promise to resolve
 with (stdout stderr) on success and with (event stdout stderr) on error
-with stdin `buffer-string' of BUF."
+with STRING as stdin."
   (apply #'promise:make-process-with-handler
          program
          (lambda (proc)

--- a/promise.el
+++ b/promise.el
@@ -226,6 +226,50 @@ with (stdout stderr) on success and with (event stdout stderr) on error."
          (error (funcall cleanup)
                 (signal (car err) (cdr err))))))))
 
+(defun promise:make-process-with-buffer-string (program buf &rest args)
+  "Generate an asynchronous process and return Promise to resolve
+with (stdout stderr) on success and with (event stdout stderr) on error
+with stdin `buffer-string' of BUF."
+  (apply #'promise:make-process-with-string
+         `(,program ,(with-current-buffer buf (buffer-string)) ,@args)))
+
+(defun promise:make-process-with-string (program string &rest args)
+  "Generate an asynchronous process and return Promise to resolve
+with (stdout stderr) on success and with (event stdout stderr) on error
+with stdin `buffer-string' of BUF."
+  (promise-new
+   (lambda (resolve reject)
+     (let* ((stdout (generate-new-buffer (concat "*" program "-stdout*")))
+            (stderr (generate-new-buffer (concat "*" program "-stderr*")))
+            (stderr-pipe (make-pipe-process
+                          :name (concat "*" program "-stderr-pipe*")
+                          :noquery t
+                          ;; use :filter instead of :buffer, to get rid of "Process Finished" lines
+                          :filter (lambda (_ output)
+                                    (with-current-buffer stderr
+                                      (insert output)))))
+            (cleanup (lambda ()
+                       (delete-process stderr-pipe)
+                       (kill-buffer stdout)
+                       (kill-buffer stderr))))
+       (condition-case err
+           (let ((proc (make-process :name program
+                                     :buffer stdout
+                                     :command (cons program args)
+                                     :stderr stderr-pipe
+                                     :sentinel (lambda (process event)
+                                                 (unwind-protect
+                                                     (let ((stderr-str (with-current-buffer stderr (buffer-string)))
+                                                           (stdout-str (with-current-buffer stdout (buffer-string))))
+                                                       (if (string= event "finished\n")
+                                                           (funcall resolve (list stdout-str stderr-str))
+                                                         (funcall reject (list event stdout-str stderr-str))))
+                                                   (funcall cleanup))))))
+             (process-send-string proc string)
+             (process-send-eof proc))
+         (error (funcall cleanup)
+                (signal (car err) (cdr err))))))))
+
 (require 'subr-x)
 (defun promise:maybe-message (msg)
   "Display message if non-blank."

--- a/promise.el
+++ b/promise.el
@@ -195,48 +195,35 @@ as below.
   "Return `Promise' to resolve with response asynchronous process.
 Generate an asynchronous process and return Promise to resolve
 with (stdout stderr) on success and with (event stdout stderr) on error."
-  (promise-new
-   (lambda (resolve reject)
-     (let* ((stdout (generate-new-buffer (concat "*" program "-stdout*")))
-            (stderr (generate-new-buffer (concat "*" program "-stderr*")))
-            (stderr-pipe (make-pipe-process
-                          :name (concat "*" program "-stderr-pipe*")
-                          :noquery t
-                          ;; use :filter instead of :buffer, to get rid of "Process Finished" lines
-                          :filter (lambda (_ output)
-                                    (with-current-buffer stderr
-                                      (insert output)))))
-            (cleanup (lambda ()
-                       (delete-process stderr-pipe)
-                       (kill-buffer stdout)
-                       (kill-buffer stderr))))
-       (condition-case err
-           (make-process :name program
-                         :buffer stdout
-                         :command (cons program args)
-                         :stderr stderr-pipe
-                         :sentinel (lambda (_process event)
-                                     (unwind-protect
-                                         (let ((stderr-str (with-current-buffer stderr (buffer-string)))
-                                               (stdout-str (with-current-buffer stdout (buffer-string))))
-                                           (if (string= event "finished\n")
-                                               (funcall resolve (list stdout-str stderr-str))
-                                             (funcall reject (list event stdout-str stderr-str))))
-                                       (funcall cleanup))))
-         (error (funcall cleanup)
-                (signal (car err) (cdr err))))))))
+  (apply #'promise:make-process-with-handler program nil args))
 
 (defun promise:make-process-with-buffer-string (program buf &rest args)
   "Generate an asynchronous process and return Promise to resolve
 with (stdout stderr) on success and with (event stdout stderr) on error
 with stdin `buffer-string' of BUF."
-  (apply #'promise:make-process-with-string
-         `(,program ,(with-current-buffer buf (buffer-string)) ,@args)))
+  (apply #'promise:make-process-with-handler
+         program
+         (lambda (proc)
+           (with-current-buffer buf
+             (process-send-region proc (point-min) (point-max))
+             (process-send-eof proc)))
+         args))
 
 (defun promise:make-process-with-string (program string &rest args)
   "Generate an asynchronous process and return Promise to resolve
 with (stdout stderr) on success and with (event stdout stderr) on error
 with stdin `buffer-string' of BUF."
+  (apply #'promise:make-process-with-handler
+         program
+         (lambda (proc)
+           (process-send-string proc string)
+           (process-send-eof proc))
+         args))
+
+(defun promise:make-process-with-handler (program handler &rest args)
+  "Generate an asynchronous process and return Promise to resolve
+with (stdout stderr) on success and with (event stdout stderr) on error.
+HANDLER is a process handler and takes one process object argument."
   (promise-new
    (lambda (resolve reject)
      (let* ((stdout (generate-new-buffer (concat "*" program "-stdout*")))
@@ -259,14 +246,18 @@ with stdin `buffer-string' of BUF."
                                      :stderr stderr-pipe
                                      :sentinel (lambda (process event)
                                                  (unwind-protect
-                                                     (let ((stderr-str (with-current-buffer stderr (buffer-string)))
-                                                           (stdout-str (with-current-buffer stdout (buffer-string))))
+                                                     (let ((stderr-str (with-current-buffer stderr
+                                                                         (buffer-string)))
+                                                           (stdout-str (with-current-buffer stdout
+                                                                         (buffer-string))))
                                                        (if (string= event "finished\n")
-                                                           (funcall resolve (list stdout-str stderr-str))
-                                                         (funcall reject (list event stdout-str stderr-str))))
+                                                           (funcall resolve
+                                                                    (list stdout-str stderr-str))
+                                                         (funcall reject
+                                                                  (list event stdout-str stderr-str))))
                                                    (funcall cleanup))))))
-             (process-send-string proc string)
-             (process-send-eof proc))
+             (when handler
+               (funcall handler proc)))
          (error (funcall cleanup)
                 (signal (car err) (cdr err))))))))
 

--- a/promise.el
+++ b/promise.el
@@ -212,7 +212,7 @@ with stdin `buffer-string' of BUF."
 (defun promise:make-process-with-string (program string &rest args)
   "Generate an asynchronous process and return Promise to resolve
 with (stdout stderr) on success and with (event stdout stderr) on error
-with stdin `buffer-string' of BUF."
+with STRING as stdin."
   (apply #'promise:make-process-with-handler
          program
          (lambda (proc)

--- a/promise.el
+++ b/promise.el
@@ -4,7 +4,7 @@
 
 ;; Author: chuntaro <chuntaro@sakura-games.jp>
 ;; URL: https://github.com/chuntaro/emacs-promise
-;; Package-Requires: ((emacs "26.1") (async "1.9"))
+;; Package-Requires: ((emacs "25") (async "1.9"))
 ;; Version: 1.1
 ;; Keywords: async promise convenience
 
@@ -192,8 +192,7 @@ as below.
                     (funcall reject reason))))))
 
 (defun promise:make-process (program &rest args)
-  "Return `Promise' to resolve with response asynchronous process.
-Generate an asynchronous process and return Promise to resolve
+  "Generate an asynchronous process and return Promise to resolve
 with (stdout stderr) on success and with (event stdout stderr) on error."
   (apply #'promise:make-process-with-handler program nil args))
 
@@ -212,7 +211,7 @@ with stdin `buffer-string' of BUF."
 (defun promise:make-process-with-string (program string &rest args)
   "Generate an asynchronous process and return Promise to resolve
 with (stdout stderr) on success and with (event stdout stderr) on error
-with STRING as stdin."
+with stdin `buffer-string' of BUF."
   (apply #'promise:make-process-with-handler
          program
          (lambda (proc)
@@ -263,15 +262,14 @@ HANDLER is a process handler and takes one process object argument."
 
 (require 'subr-x)
 (defun promise:maybe-message (msg)
-  "Display message if non-blank."
+  "Display message if non-blank"
   (let ((m (string-trim-right msg)))
     (when (not (string-empty-p m))
       (message "%s" m))))
 
 (require 'seq)
 (defun promise:make-process-string (program &rest args)
-  "Return `Promise' to resolve with generate an asynchronous process.
-Generate an asynchronous process and return Promise to resolve
+  "Generate an asynchronous process and return Promise to resolve
 with stdout on success and with event on error."
   (promise-then
    (apply #'promise:make-process program args)
@@ -286,7 +284,7 @@ with stdout on success and with event on error."
        (promise-reject event)))))
 
 (defun promise:make-shell-command (script)
-  "Run script in shell and return."
+  "Run script in shell and return"
   (promise:make-process-string shell-file-name shell-command-switch script))
 
 (defun promise:make-thread (f &rest args)
@@ -356,7 +354,7 @@ with stdout on success and with event on error."
 (declare-function async-when-done "async.el" (proc &optional _change))
 
 (defun promise:async-start (start-func &optional finish-func)
-  "Return `Promise' to resolve with the `async-start' return value."
+  "Return Promise to resolve with the `async-start' return value."
   (promise-new
    (lambda (resolve reject)
      (set-process-sentinel (async-start start-func

--- a/promise.el
+++ b/promise.el
@@ -225,45 +225,6 @@ with (stdout stderr) on success and with (event stdout stderr) on error."
          (error (funcall cleanup)
                 (signal (car err) (cdr err))))))))
 
-(defun promise:make-process-with-string (program string &rest args)
-  "Generate an asynchronous process and return Promise to resolve
-with (stdout stderr) on success and with (event stdout stderr) on error
-with stdin `buffer-string' of BUF."
-  (promise-new
-   (lambda (resolve reject)
-     (let* ((stdout (generate-new-buffer (concat "*" program "-stdout*")))
-            (stderr (generate-new-buffer (concat "*" program "-stderr*")))
-            (stderr-pipe (make-pipe-process
-                          :name (concat "*" program "-stderr-pipe*")
-                          :noquery t
-                          ;; use :filter instead of :buffer, to get rid of "Process Finished" lines
-                          :filter (lambda (_ output)
-                                    (with-current-buffer stderr
-                                      (insert output)))))
-            (cleanup (lambda ()
-                       (delete-process stderr-pipe)
-                       (kill-buffer stdout)
-                       (kill-buffer stderr))))
-       (condition-case err
-           (let ((proc (make-process :name program
-                                     :buffer stdout
-                                     :command (cons program args)
-                                     :stderr stderr-pipe
-                                     :sentinel (lambda (process event)
-                                                 (unwind-protect
-                                                     (let ((stderr-str (with-current-buffer stderr (buffer-string)))
-                                                           (stdout-str (with-current-buffer stdout (buffer-string))))
-                                                       (if (string= event "finished\n")
-                                                           (funcall resolve (list stdout-str stderr-str))
-                                                         (funcall reject (list event stdout-str stderr-str))))
-                                                   (funcall cleanup))))))
-             (with-temp-buffer
-               (insert (substring-no-properties string))
-               (process-send-region proc (point-min) (point-max))
-               (process-send-eof proc)))
-         (error (funcall cleanup)
-                (signal (car err) (cdr err))))))))
-
 (defun promise:make-process-with-buffer-string (program buf &rest args)
   "Generate an asynchronous process and return Promise to resolve
 with (stdout stderr) on success and with (event stdout stderr) on error
@@ -301,6 +262,20 @@ with stdin `buffer-string' of BUF."
                (process-send-eof proc)))
          (error (funcall cleanup)
                 (signal (car err) (cdr err))))))))
+
+(defun promise:make-process-with-string (program string &rest args)
+  "Generate an asynchronous process and return Promise to resolve
+with (stdout stderr) on success and with (event stdout stderr) on error
+with stdin `buffer-string' of BUF."
+  ;; reference `with-temp-buffer'
+  (let ((temp-buffer (generate-new-buffer " *temp*")))
+    (with-current-buffer temp-buffer
+      (unwind-protect
+          (progn
+            (insert (substring-no-properties string))
+            (apply #'promise:make-process-with-buffer-string `(,temp-buffer ,@args)))
+        (and (buffer-name temp-buffer)
+             (kill-buffer temp-buffer))))))
 
 (require 'subr-x)
 (defun promise:maybe-message (msg)


### PR DESCRIPTION
Hi!
I add function which returns promise to resolve process with some stdin.

``` emacs-lisp
(display-buffer (get-buffer-create "*async*"))
;;=> #<window 941 on *async*>

(funcall
 (async-lambda ()
   (let ((res (await (promise:make-process-with-string "cat" user-emacs-directory))))
     (with-current-buffer "*async*"
       (message "done!")
       (insert (pp-to-string res))))))
;;=> #s(promise-class 0 0 nil nil nil)

---------- Buffer: *async* ----------
("/home/conao/.emacs.d/local/26.3/" "")
---------- Buffer: *async* ----------

;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

(funcall
 (async-lambda ()
   (let ((res (await (promise:make-process-with-buffer-string "cat" "*async*"))))
     (with-current-buffer "*async*"
       (message "done!")
       (insert (pp-to-string res))))))
;;=> #s(promise-class 0 0 nil nil nil)

---------- Buffer: *async* ----------
("(\"/home/conao/.emacs.d/local/26.3/\" \"\")\n" "")
("/home/conao/.emacs.d/local/26.3/" "")
---------- Buffer: *async* ----------
```