### PR TITLE
Require subr-x when compile time

### DIFF
--- a/promise-core.el
+++ b/promise-core.el
@@ -54,6 +54,7 @@
 
 (require 'eieio)
 (require 'cl-lib)
+(eval-when-compile (require 'subr-x))
 
 (defun promise--asap (task)
   (run-at-time 0.001 nil task))


### PR DESCRIPTION
Hi!

This fixes below byte-compiler warnings.
> reference to free variable ‘method’ (emacs-lisp)