### PR TITLE
Remove async dependency

### DIFF
--- a/promise.el
+++ b/promise.el
@@ -4,7 +4,7 @@
 
 ;; Author: chuntaro <chuntaro@sakura-games.jp>
 ;; URL: https://github.com/chuntaro/emacs-promise
-;; Package-Requires: ((emacs "26.1") (async "1.9"))
+;; Package-Requires: ((emacs "26.1"))
 ;; Version: 1.1
 ;; Keywords: async promise convenience
 
@@ -474,6 +474,7 @@ Resolve:
 
 Reject:
   - Error object while evaluating START-FUNC and FINISH-FUNC."
+  (require 'async)
   (promise-new
    (lambda (resolve reject)
      (set-process-sentinel (async-start start-func


### PR DESCRIPTION
こんにちは。

`Package-Requires:` から `async` を削除しました。

emacs-promiseというパッケージを知らない人から見ると、このパッケージの非同期実行がasyncによってなされているかのように誤認する可能性があり、実際、私は誤認していました。
asyncはpromise:async-startのみが依存していて、そのような場合、関数内部でrequireすることによって要件を満たせます。
この手法は他のパッケージでも行なわれており、Emacs添付のパッケージでも見られます。

(個人的には `emacs -Q --batch --eval` に渡すだけなので、asyncに依存する利点があまりないように思いますが、その議論は他のPRですかね。。)