### PR TITLE
Remove needless depends-on specification

### DIFF
--- a/Cask
+++ b/Cask
@@ -3,9 +3,6 @@
 
 (package-file "promise.el")
 
-(depends-on "eieio")
-(depends-on "cl-lib")
-
 (development
  (depends-on "f")
  (depends-on "ert")


### PR DESCRIPTION
こんにちは。

Caskファイルにおいて、eieioとcl-libの指定を削除しました。
caskは `package-file` の `Package-Requires` セクションを依存解決で参照するので、 `development` でない、パッケージの依存は `Package-Requires` に普通に書けば情報の二重管理を防げます。

今回のeieioとcl-libに関しては `Package-Requires` に `(emacs "25.1")` が記載されているので、これらのパッケージはビルトインです。