### PR TITLE
Change promise-chain argument form

### DIFF
--- a/promise.el
+++ b/promise.el
@@ -96,8 +96,8 @@
 (require 'promise-rejection-tracking)
 
 ;;;###autoload
-(defmacro promise-chain (&rest body)
-  "Extract BODY include then, catch, done and finally.
+(defmacro promise-chain (promise &rest body)
+  "Extract PROMISE, BODY include then, catch, done and finally.
 
 Extract the following code...
 
@@ -137,7 +137,7 @@ as below.
                                        ...)))
       promise)"
   (declare (indent 1) (debug t))
-  `(let ((promise ,(car body)))
+  `(let ((promise ,promise))
      ,@(mapcar (lambda (sexp)
                  (let ((fn (car-safe sexp))
                        (args (cdr-safe sexp)))
@@ -159,7 +159,7 @@ as below.
                       `(setf promise (promise-finally promise ,@args)))
                      (otherwise
                       sexp))))
-               (cdr body))
+               body)
      promise))
 
 ;;


### PR DESCRIPTION
こんにちは。
`promise-chain` の引数の形を変えました。
引数をまとめて `body` で受け取っていますが、 擬似的にはpromise-chainの第一引数が `promise` を期待していて、その後の全てが `then` や `catch` の指定を期待しています。

`el-doc` 用の特殊なdocstringを書こうとしたのですが、そもそもの引数を直すことでも対応できるので、このように対応しました。
手元では簡単な例について以前と同じように動くことを確認しました。