### PR TITLE
Add promise-wait-value

### DIFF
--- a/promise.el
+++ b/promise.el
@@ -531,5 +531,13 @@ Timeout:
                         (throw 'done (promise-reject `(:rejected ,reason))))))
       (while t (accept-process-output)))))
 
+(defun promise-wait-value (promise)
+  "Return orignal value form PROMISE return value of `promise-wait'."
+  (seq-let (state value) (_value promise)
+    (cond
+     ((eq :fullfilled state) value)
+     ((eq :rejected  state) (error "Rejected: %s" (prin1-to-string value)))
+     ((eq :timeouted state) (error "Timeouted: %s" (prin1-to-string value))))))
+
 (provide 'promise)
 ;;; promise.el ends here


### PR DESCRIPTION
`promise-wait` を使っていたのですが、 `(cadr (_value) ...)` がイディオムとしておまじないになっているので、 `promise-wait-value` として定義しました。

使い方としては単に `(cadr (_value) ...)` を置き換えるだけです。

``` emacs-lisp
(progn
  (setq promises (list (promise:delay 2 'delay2)
                       (promise:delay 1 'delay1)
                       (promise:delay 3 'delay3)
                       (promise:delay 1 'delay1)))
  (setq first (cadr
               (_value
                (promise-wait 5 (promise-race promises))))))
;;=> delay1


(progn
  (setq promises (list (promise:delay 2 'delay2)
                       (promise:delay 1 'delay1)
                       (promise:delay 3 'delay3)
                       (promise:delay 1 'delay1)))
  (setq first (promise-wait-value
               (promise-wait 5 (promise-race promises)))))
;;=> delay1
```