### PR TITLE
Fix promise-new special handler in promise-chain

### DIFF
--- a/promise.el
+++ b/promise.el
@@ -143,7 +143,7 @@ as below.
                        (args (cdr-safe sexp)))
                    (cl-case fn
                      (promise-new
-                      `(setf promise ,@sexp))
+                      `(setf promise ,sexp))
                      ((promise-then
                        promise-catch
                        promise-done


### PR DESCRIPTION
こんにちは

`promise-chain` で `promise-new` だけなぜか特別扱いされているのですが、実際にpromise-newを渡すと展開結果の `setf` がおかしな式になるようです。


``` emacs-lisp
;; before this PR merge
(ppp-macroexpand
 (promise-chain (promise:delay 0)
   (then (lambda (res)
           (warn (prin1-to-string res))))
   (promise-new (lambda (resolve reject)
                  (funcall resolve 'promise)))
   (then (lambda (res)
           (warn (prin1-to-string res))))))
;;=> (let ((promise
;;          (promise:delay 0)))
;;     (setf promise
;;           (promise-then promise
;;                         (lambda (res)
;;                           (warn
;;                            (prin1-to-string res)))))
;;     (setf promise promise-new
;;           (lambda (resolve reject)
;;             (funcall resolve 'promise)))
;;     (setf promise
;;           (promise-then promise
;;                         (lambda (res)
;;                           (warn
;;                            (prin1-to-string res)))))
;;     promise)


;; after this PR merge
(ppp-macroexpand
 (promise-chain (promise:delay 0)
   (then (lambda (res)
           (warn (prin1-to-string res))))
   (promise-new (lambda (resolve reject)
                  (funcall resolve 'promise)))
   (then (lambda (res)
           (warn (prin1-to-string res))))))
;;=> (let ((promise
;;          (promise:delay 0)))
;;     (setf promise
;;           (promise-then promise
;;                         (lambda (res)
;;                           (warn
;;                            (prin1-to-string res)))))
;;     (setf promise
;;           (promise-new promise
;;                        (lambda (resolve reject)
;;                          (funcall resolve 'promise))))
;;     (setf promise
;;           (promise-then promise
;;                         (lambda (res)
;;                           (warn
;;                            (prin1-to-string res)))))
;;     promise)
```

ということで `promise-new` を `promise-then` などと同じように処理するように変更しました。