### PR TITLE
Change arg fromat

### DIFF
--- a/examples/promise-examples.el
+++ b/examples/promise-examples.el
@@ -289,7 +289,7 @@ and resolves it in the output result."
 (defun example14 ()
   "Same result as `example13'."
   (promise-chain (promise:make-process-string
-                  "grep" "make-process" "promise-examples.el")
+                  '("grep" "make-process" "promise-examples.el"))
     (then (lambda (result)
             (message "grep result:\n%s" result)))
 
@@ -299,7 +299,7 @@ and resolves it in the output result."
 (defun example15 ()
   "An example when `make-process' returns an error."
   (promise-chain (promise:make-process-string
-                  "grep" "string not in source \\ " "promise-examples.el")
+                  '("grep" "string not in source \\ " "promise-examples.el"))
     (then (lambda (result)
             (message "grep result:\n%s" result)))
 


### PR DESCRIPTION
こんにちは。
以前私が提案したコードをさらに修正することになって申し訳ないのですが、引数の受け取り方を変更したいと考えています。

現在、ハンドラーが第2引数、コマンド名とその他の引数が第1引数と第3引数以降というように分断されており、コードを読む際に引っ掛かりがあります。
このパッチのように、コマンドはリストとして渡すことにすると、コマンドの分断は解消され、 `promise:make-process-with-handler` のオプション引数も `&optional` で自然に運用できます。

```elisp
(apply #'promise:make-process-with-handler
       program
       (lambda (proc)
         (with-current-buffer buf
           (process-send-region proc (point-min) (point-max))
           (process-send-eof proc)))
       args))
```
```elisp
(funcall #'promise:make-process-with-handler
         command
         (lambda (proc)
           (with-current-buffer buf
             (process-send-region proc (point-min) (point-max))
             (process-send-eof proc)))))
```

また、このようにプログラムと引数をそのまま書いていくのは `call-process` に似ていますが、関数名は `make-process` であり、 `make-process` には文字列のリストを渡すのが自然なような気がします。

さらに、Emacsからコマンド文字列を組み立てる際は `shell-quote-argument` を[通すべき](https://qiita.com/tadsan/items/17d32514b81f1e8f208a#%E3%81%A9%E3%81%86%E3%81%99%E3%82%8C%E3%81%B0%E3%82%88%E3%81%84%E3%81%AE%E3%81%8B)ですが、これもリストを渡すのであれば `mapcar` で `shell-quote-argument` を適用後に自然に渡せます。

ただ、APIを変えたので、その影響範囲が気になるところです。
現在、MELPAでは次のようなパッケージがこのパッケージに依存しています。

- promise - https://melpa.org/#/promise
  - async-await - https://github.com/chuntaro/emacs-async-await
    - dired-git - https://github.com/conao3/dired-git.el
    - feather - https://github.com/conao3/feather.el
    - indent-lint - https://github.com/conao3/indent-lint.el
      - flycheck-indent - https://github.com/conao3/indent-lint.el
  - hnreader - https://github.com/thanhvg/emacs-hnreader
  - howdoyou - https://github.com/thanhvg/emacs-howdoyou
  - semaphore-promise - https://github.com/webnf/semaphore.el

しかし、幸いながら、私のパッケージ以外で、今回書き換えた関数は使用されていないようです。

async-awaitのテストには含まれているので、変更する必要があります。

ご検討よろしくお願いします。