### PR TITLE
Add promise:t as a dummy promise

### DIFF
--- a/promise.el
+++ b/promise.el
@@ -190,6 +190,18 @@ as below.
 
 (require 'url-http)
 
+(defconst promise:t promise--t
+  "Return promise to return constant t immediately.
+
+Arguments:
+  - <None>
+
+Resolve:
+  - t
+
+Reject:
+  - <Never rejected>")
+
 (defun promise:run-at-time (time function &rest args)
   "Return promise to funcall FUNCTION with ARGS at specified TIME.
 


### PR DESCRIPTION
`promise:t` という新しい promise を定義しました。
これは `promise-es6-extensions` で定義されている `promise--t` と
同じですが、ハイフン2個の変数のため外で使うのは少し抵抗があったた
め、このように定義しました。

この定数は主に promise-chain で使います。
promise-example から例を出すと
```elisp
(defun do-something ()
  "Return `Promise' to resolve the value synchronously."
  (promise-new (lambda (resolve _reject)
                 (let ((value 33))
                   (funcall resolve value)))))

(defun example3 ()
  "Same result as `example2'.
`promise-chain' macro is a syntax sugar for easy writing."
  (promise-chain (do-something)
    (then (lambda (result)
            (message "first result: %s" result)
            88))

    (then (lambda (second-result)
            (message "second result: %s" second-result)
            99))

    (then (lambda (third-result)
            (message "third result: %s" third-result)))))
```
は do-something のような関数を書かずに、このように書きたいと思っています (私は)。

```emacs-lisp
(defun example3 ()
  "Same result as `example2'.
`promise-chain' macro is a syntax sugar for easy writing."
  (promise-chain (promise-new (lambda (resolve _reject)
                                (let ((value 33))
                                  (funcall resolve value))))
    (then (lambda (result)
            (message "first result: %s" result)
            88))

    (then (lambda (second-result)
            (message "second result: %s" second-result)
            99))

    (then (lambda (third-result)
            (message "third result: %s" third-result)))))
```

しかしこれは 「33 を返す promise」 と 「then の promise」のインデ
ントの深さが異なっており、それぞれの意味を、大きく異なるかのように受け取らせています。

しかし実際にはそれぞれは同様の promise であり、 promise-then
で繋いであるだけです。

この場合、promise-chain の 第1引数として適当なpromiseを渡せば、こ
のインデントの問題を解消できます。

```elisp
(defun example3 ()
  "Same result as `example2'.
`promise-chain' macro is a syntax sugar for easy writing."
  (promise-chain (promise-new (lambda (resolve _) (funcall resolve)))
    (then (lambda (_)
            33))

    (then (lambda (result)
            (message "first result: %s" result)
            88))

    (then (lambda (second-result)
            (message "second result: %s" second-result)
            99))

    (then (lambda (third-result)
            (message "third result: %s" third-result)))))
```

こうすることで 「意味のある」 promise が縦一列に並び、意味を捉え
やすくなります。

`promise:t` は即座に `t` を返す promise です。実際、返す値は何でも
良いのですが、このように使います。

```elisp
(defun example3 ()
  "Same result as `example2'.
`promise-chain' macro is a syntax sugar for easy writing."
  (promise-chain promise:t
    (then (lambda (_)
            33))

    (then (lambda (result)
            (message "first result: %s" result)
            88))

    (then (lambda (second-result)
            (message "second result: %s" second-result)
            99))

    (then (lambda (third-result)
            (message "third result: %s" third-result)))))
```

よろしくお願いします。